### PR TITLE
feat: add @element-plus/nuxt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@
 🏗 Working in Progress
 </pre>
 
-> Nuxt 3 is still beta, we may need to keep updating to adapt it.
-> It doesn't work very well yet.
-
 SSR Preview: <https://element-plus-nuxt.vercel.app/>
 
 SSG Preview: <https://nuxt-starter.element-plus.org/>

--- a/app.vue
+++ b/app.vue
@@ -1,10 +1,4 @@
 <script setup>
-import { ID_INJECTION_KEY } from 'element-plus'
-
-provide(ID_INJECTION_KEY, {
-  prefix: 100,
-  current: 0,
-})
 </script>
 
 <template>

--- a/components/Counter.vue
+++ b/components/Counter.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { ElInputNumber } from "element-plus";
 const { count } = useCount();
 </script>
 

--- a/components/Examples.vue
+++ b/components/Examples.vue
@@ -1,7 +1,10 @@
 <template>
   <el-dropdown class="m-4" type="primary">
     <el-button type="primary">
-      Dropdown List<el-icon class="el-icon--right"><arrow-down /></el-icon>
+      Dropdown List
+      <el-icon class="el-icon--right">
+        <el-icon-arrow-down />
+      </el-icon>
     </el-button>
     <template #dropdown>
       <el-dropdown-menu>
@@ -16,7 +19,7 @@
 
   <br />
 
-  <el-button class="m-4" @click="hello">Hello</el-button>
+  <el-button :icon="ElIconView" class="m-4" @click="hello">Hello</el-button>
   <el-button class="m-4" type="primary" @click="hello">Hello</el-button>
   <el-button class="m-4" type="success" @click="helloSuccess">Hello</el-button>
 
@@ -27,41 +30,28 @@
   <br />
 
   <el-icon class="cursor-pointer">
-    <Grape />
+    <el-icon-grape />
   </el-icon>
   <el-icon class="cursor-pointer">
-    <IceCream />
+    <ElIconIceCream />
   </el-icon>
   <el-icon class="cursor-pointer mb-4">
-    <IceDrink />
+    <ElIconIceDrink />
   </el-icon>
 
   <br />
 
-  <client-only>
-    <el-config-provider :locale="zhCn">
-      <el-date-picker
-        v-model="timeValue"
-        type="date"
-        placeholder="请选择日期"
-      ></el-date-picker>
-    </el-config-provider>
-  </client-only>
+  <el-config-provider :locale="zhCn">
+    <el-date-picker
+      v-model="timeValue"
+      type="date"
+      placeholder="请选择日期"
+    />
+  </el-config-provider>
 </template>
 
 <script setup lang="ts">
-import {
-  ElIcon,
-  ElButton,
-  ElDropdown,
-  ElDropdownMenu,
-  ElDropdownItem,
-  ElConfigProvider,
-  ElDatePicker,
-  ElMessage,
-} from "element-plus";
 import zhCn from "element-plus/es/locale/lang/zh-cn";
-import { Grape, IceCream, IceDrink, ArrowDown } from "@element-plus/icons-vue";
 
 const timeValue = ref("");
 const hello = () => ElMessage.info("hello world");

--- a/components/Logos.vue
+++ b/components/Logos.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { ElIcon } from 'element-plus'
-import { Plus } from '@element-plus/icons-vue'
 </script>
 
 <template>
@@ -9,7 +7,7 @@ import { Plus } from '@element-plus/icons-vue'
       class="logo"
       src="https://element-plus.org/images/element-plus-logo.svg"
     />
-    <el-icon><Plus /></el-icon>
+    <el-icon><ElIconPlus /></el-icon>
     <NuxtLogo class="logo" />
   </div>
   <h2>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,3 @@
-import ElementPlus from 'unplugin-element-plus/vite'
-
 // https://v3.nuxtjs.org/docs/directory-structure/nuxt.config
 export default defineNuxtConfig({
   app: {
@@ -21,25 +19,18 @@ export default defineNuxtConfig({
   // css
   css: ['~/assets/scss/index.scss'],
 
-  // build
-  build: {
-    transpile: ['element-plus/es'],
-  },
-
   typescript: {
     strict: true,
     shim: false,
   },
 
-  vite: {
-    plugins: [ElementPlus()],
-  },
-
   // build modules
-  modules: ['@vueuse/nuxt', '@unocss/nuxt', '@pinia/nuxt'],
-
-  // auto import components
-  components: true,
+  modules: [
+    '@vueuse/nuxt',
+    '@unocss/nuxt',
+    '@pinia/nuxt',
+    '@element-plus/nuxt',
+  ],
 
   // vueuse
   vueuse: {
@@ -52,5 +43,9 @@ export default defineNuxtConfig({
     icons: {
       scale: 1.2,
     },
+  },
+
+  elementPlus: {
+    icon: 'ElIcon',
   },
 })

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@element-plus/icons-vue": "^2.0.10",
+    "@element-plus/nuxt": "^1.0.1",
     "@pinia/nuxt": "^0.4.6",
     "@unocss/nuxt": "^0.48.0",
     "@vueuse/nuxt": "^9.9.0",
@@ -26,14 +27,14 @@
     "nuxt": "^3.0.0",
     "sass": "^1.57.1",
     "typescript": "^4.9.4",
-    "unplugin-element-plus": "^0.4.1",
     "vue-router": "^4.1.6"
   },
   "pnpm": {
     "peerDependencyRules": {
       "ignoreMissing": [
         "webpack",
-        "vite"
+        "vite",
+        "vue"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@element-plus/icons-vue": "^2.0.10",
-    "@element-plus/nuxt": "^1.0.1",
+    "@element-plus/nuxt": "^1.0.2",
     "@pinia/nuxt": "^0.4.6",
     "@unocss/nuxt": "^0.48.0",
     "@vueuse/nuxt": "^9.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@element-plus/icons-vue': ^2.0.10
-  '@element-plus/nuxt': ^1.0.1
+  '@element-plus/nuxt': ^1.0.2
   '@pinia/nuxt': ^0.4.6
   '@unocss/nuxt': ^0.48.0
   '@vueuse/nuxt': ^9.9.0
@@ -14,7 +14,7 @@ specifiers:
 
 devDependencies:
   '@element-plus/icons-vue': 2.0.10
-  '@element-plus/nuxt': 1.0.1_tjzx7iko7dkq2vnhx32zq7iuiu
+  '@element-plus/nuxt': 1.0.2_tjzx7iko7dkq2vnhx32zq7iuiu
   '@pinia/nuxt': 0.4.6_typescript@4.9.4
   '@unocss/nuxt': 0.48.0
   '@vueuse/nuxt': 9.9.0_nuxt@3.0.0
@@ -355,10 +355,13 @@ packages:
     resolution: {integrity: sha512-ygEZ1mwPjcPo/OulhzLE7mtDrQBWI8vZzEWSNB2W/RNCRjoQGwbaK4N8lV4rid7Ts4qvySU3njMN7YCiSlSaTQ==}
     peerDependencies:
       vue: ^3.2.0
+    peerDependenciesMeta:
+      vue:
+        optional: true
     dev: true
 
-  /@element-plus/nuxt/1.0.1_tjzx7iko7dkq2vnhx32zq7iuiu:
-    resolution: {integrity: sha512-77amq7e4DYxINYiijenp+0aiqBcqEZfNjA94LZZNk83DpA+xX7nM+cFaAOT02mzNzlhMXCCoWT1SyzRyKEw7og==}
+  /@element-plus/nuxt/1.0.2_tjzx7iko7dkq2vnhx32zq7iuiu:
+    resolution: {integrity: sha512-ztEtmBvsgdbOatQyFgCxZnYh/cVHolyRWRNJgddP72Nek5IgwZYkwA48Chpz5druE5XKGrkzYIByvcCX4NAsGw==}
     peerDependencies:
       '@element-plus/icons-vue': '>=0.2.6'
       element-plus: '>=2'
@@ -651,6 +654,9 @@ packages:
     engines: {node: ^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     peerDependencies:
       vue: ^3.2.45
+    peerDependenciesMeta:
+      vue:
+        optional: true
     dependencies:
       '@nuxt/kit': 3.0.0_rollup@2.79.1
       '@rollup/plugin-replace': 5.0.2_rollup@2.79.1
@@ -918,6 +924,9 @@ packages:
     resolution: {integrity: sha512-PwJLCSq/eVLbLw7SbMCa20rEeL301w52UG2YhRpQTfsChBMBRGg3Nsl/PPWIurwkBXPpCsVL3AFppaCK5BCJ5Q==}
     peerDependencies:
       vue: '>=2.7 || >=3'
+    peerDependenciesMeta:
+      vue:
+        optional: true
     dependencies:
       '@unhead/schema': 1.0.14
       hookable: 5.4.2
@@ -1162,6 +1171,8 @@ packages:
     peerDependenciesMeta:
       vite:
         optional: true
+      vue:
+        optional: true
     dependencies:
       '@babel/core': 7.20.7
       '@babel/plugin-transform-typescript': 7.20.7_@babel+core@7.20.7
@@ -1180,6 +1191,8 @@ packages:
       vue: ^3.2.25
     peerDependenciesMeta:
       vite:
+        optional: true
+      vue:
         optional: true
     dependencies:
       vite: 3.2.5_sass@1.57.1
@@ -1284,6 +1297,9 @@ packages:
     resolution: {integrity: sha512-ebiMq7q24WBU1D6uhPK//2OTR1iRIyxjF5iVq/1a5I1SDMDyDu4Ts6fJaMnjrvD3MqnaiFkKQj+LKAgz5WIK3g==}
     peerDependencies:
       vue: 3.2.45
+    peerDependenciesMeta:
+      vue:
+        optional: true
     dependencies:
       '@vue/compiler-ssr': 3.2.45
       '@vue/shared': 3.2.45
@@ -1310,6 +1326,9 @@ packages:
     resolution: {integrity: sha512-YmUdbzNdCnhmrAFxGnJS+Rixj+swE+TQC9OEaYDHIro6gE7W11jugcdwVP00HrA4WRQhg+TOQ4YcY2oL/PP1hw==}
     peerDependencies:
       vue: '>=2.7 || >=3'
+    peerDependenciesMeta:
+      vue:
+        optional: true
     dependencies:
       '@unhead/dom': 1.0.14
       '@unhead/schema': 1.0.14
@@ -2113,6 +2132,9 @@ packages:
     resolution: {integrity: sha512-P04HDOZBYDdvlYuleuCZRULzAc5xJVOBfLDK9xWxVo0vyo8ntdaXS5sTU+/76vrNzuO3FhLn9kvrsbiJEVa1jg==}
     peerDependencies:
       vue: ^3.2.0
+    peerDependenciesMeta:
+      vue:
+        optional: true
     dependencies:
       '@ctrl/tinycolor': 3.5.0
       '@element-plus/icons-vue': 2.0.10
@@ -3784,6 +3806,8 @@ packages:
         optional: true
       typescript:
         optional: true
+      vue:
+        optional: true
     dependencies:
       '@vue/devtools-api': 6.4.5
       typescript: 4.9.4
@@ -5053,6 +5077,8 @@ packages:
     peerDependenciesMeta:
       '@vue/composition-api':
         optional: true
+      vue:
+        optional: true
     dev: true
 
   /vue-devtools-stub/0.1.0:
@@ -5063,6 +5089,9 @@ packages:
     resolution: {integrity: sha512-DYWYwsG6xNPmLq/FmZn8Ip+qrhFEzA14EI12MsMgVxvHFDYvlr4NXpVF5hrRH1wVcDP8fGi5F4rxuJSl8/r+EQ==}
     peerDependencies:
       vue: ^3.2.0
+    peerDependenciesMeta:
+      vue:
+        optional: true
     dependencies:
       '@vue/devtools-api': 6.4.5
     dev: true
@@ -5071,6 +5100,9 @@ packages:
     resolution: {integrity: sha512-DYWYwsG6xNPmLq/FmZn8Ip+qrhFEzA14EI12MsMgVxvHFDYvlr4NXpVF5hrRH1wVcDP8fGi5F4rxuJSl8/r+EQ==}
     peerDependencies:
       vue: ^3.2.0
+    peerDependenciesMeta:
+      vue:
+        optional: true
     dependencies:
       '@vue/devtools-api': 6.4.5
       vue: 3.2.45

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@element-plus/icons-vue': ^2.0.10
+  '@element-plus/nuxt': ^1.0.1
   '@pinia/nuxt': ^0.4.6
   '@unocss/nuxt': ^0.48.0
   '@vueuse/nuxt': ^9.9.0
@@ -9,11 +10,11 @@ specifiers:
   nuxt: ^3.0.0
   sass: ^1.57.1
   typescript: ^4.9.4
-  unplugin-element-plus: ^0.4.1
   vue-router: ^4.1.6
 
 devDependencies:
   '@element-plus/icons-vue': 2.0.10
+  '@element-plus/nuxt': 1.0.1_tjzx7iko7dkq2vnhx32zq7iuiu
   '@pinia/nuxt': 0.4.6_typescript@4.9.4
   '@unocss/nuxt': 0.48.0
   '@vueuse/nuxt': 9.9.0_nuxt@3.0.0
@@ -21,7 +22,6 @@ devDependencies:
   nuxt: 3.0.0_i6pugmai7ijdp77xabx7o4exnq
   sass: 1.57.1
   typescript: 4.9.4
-  unplugin-element-plus: 0.4.1
   vue-router: 4.1.6
 
 packages:
@@ -355,6 +355,22 @@ packages:
     resolution: {integrity: sha512-ygEZ1mwPjcPo/OulhzLE7mtDrQBWI8vZzEWSNB2W/RNCRjoQGwbaK4N8lV4rid7Ts4qvySU3njMN7YCiSlSaTQ==}
     peerDependencies:
       vue: ^3.2.0
+    dev: true
+
+  /@element-plus/nuxt/1.0.1_tjzx7iko7dkq2vnhx32zq7iuiu:
+    resolution: {integrity: sha512-77amq7e4DYxINYiijenp+0aiqBcqEZfNjA94LZZNk83DpA+xX7nM+cFaAOT02mzNzlhMXCCoWT1SyzRyKEw7og==}
+    peerDependencies:
+      '@element-plus/icons-vue': '>=0.2.6'
+      element-plus: '>=2'
+    dependencies:
+      '@element-plus/icons-vue': 2.0.10
+      '@nuxt/kit': 3.0.0
+      element-plus: 2.2.27
+      magic-string: 0.27.0
+      unplugin: 1.0.1
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
     dev: true
 
   /@esbuild/android-arm/0.15.18:
@@ -2162,10 +2178,6 @@ packages:
     hasBin: true
     dependencies:
       prr: 1.0.1
-    dev: true
-
-  /es-module-lexer/0.10.5:
-    resolution: {integrity: sha512-+7IwY/kiGAacQfY+YBhKMvEmyAJnw5grTUgjG85Pe7vcUI/6b7pZjZG8nQ7+48YhzEAEqrEgD2dCz/JIK+AYvw==}
     dev: true
 
   /esbuild-android-64/0.15.18:
@@ -4825,44 +4837,6 @@ packages:
       - vite
     dev: true
 
-  /unplugin-element-plus/0.4.1:
-    resolution: {integrity: sha512-x8L35sppkbtnAf+aSPXNsLPjCUrM0mWKgujqMIgrHiDQaGbpMlNnbN2kjP5CMclykNOw8fUCreEhtxPyzg8tmw==}
-    engines: {node: '>=14.19.0'}
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      es-module-lexer: 0.10.5
-      magic-string: 0.26.7
-      unplugin: 0.7.2
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - vite
-      - webpack
-    dev: true
-
-  /unplugin/0.7.2:
-    resolution: {integrity: sha512-m7thX4jP8l5sETpLdUASoDOGOcHaOVtgNyrYlToyQUvILUtEzEnngRBrHnAX3IKqooJVmXpoa/CwQ/QqzvGaHQ==}
-    peerDependencies:
-      esbuild: '>=0.13'
-      rollup: ^2.50.0
-      vite: ^2.3.0 || ^3.0.0-0
-      webpack: 4 || 5
-    peerDependenciesMeta:
-      esbuild:
-        optional: true
-      rollup:
-        optional: true
-      vite:
-        optional: true
-      webpack:
-        optional: true
-    dependencies:
-      acorn: 8.8.1
-      chokidar: 3.5.3
-      webpack-sources: 3.2.3
-      webpack-virtual-modules: 0.4.6
-    dev: true
-
   /unplugin/1.0.1:
     resolution: {integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==}
     dependencies:
@@ -5130,10 +5104,6 @@ packages:
   /webpack-sources/3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
-    dev: true
-
-  /webpack-virtual-modules/0.4.6:
-    resolution: {integrity: sha512-5tyDlKLqPfMqjT3Q9TAqf2YqjwmnUleZwzJi1A5qXnlBCdj2AtOJ6wAWdglTIDOPgOiOrXeBeFcsQ8+aGQ6QbA==}
     dev: true
 
   /webpack-virtual-modules/0.5.0:


### PR DESCRIPTION
fix #50, close #47, close #32

close #36, close #27,  close #23

### About teleport component in Vue

> The `Teleport` component is used internally by multiple components in Element Plus (eg. ElDialog, ElDrawer, ElTooltip, ElDropdown, ElSelect, ElDatePicker ...)

There may be some [SSR problems with teleport](https://github.com/vuejs/core/issues?q=is%3Aissue+is%3Aopen+ssr+teleport+), so you should pay attention to the following precautions.

1. The `teleported` attribute in all components based on ElTooltip should be consistent, it is recommended to use the default value.
2. The `append-to-body` attribute value of ElDialog and ElDrawer should be consistent, it is recommended to enable the `append-to-body`.
3. When the ElSubMenu component has a multi-layer popup, It is recommended to enable the `popper-append-to-body`

Or you can use `<client-only></client-only>` as before.