### PR TITLE
feat: add custom theme & color-mode

### DIFF
--- a/assets/scss/element/dark.scss
+++ b/assets/scss/element/dark.scss
@@ -1,0 +1,6 @@
+@forward 'element-plus/theme-chalk/src/dark/var.scss' with (
+  $bg-color: (
+    'page': #0a0a0a,
+    'overlay': #1d1e1f,
+  )
+);

--- a/assets/scss/element/index.scss
+++ b/assets/scss/element/index.scss
@@ -1,0 +1,26 @@
+$-colors: (
+  'primary': (
+    'base': #ec422c,
+  ),
+  'success': (
+    'base': #67c23a,
+  ),
+  'warning': (
+    'base': #e6a23c,
+  ),
+  'danger': (
+    'base': #f56c6c,
+  ),
+  'error': (
+    'base': #f56c6c,
+  ),
+  'info': (
+    'base': #909399,
+  ),
+);
+
+@forward 'element-plus/theme-chalk/src/common/var.scss' with (
+  $colors: $-colors
+);
+
+@use './dark.scss';

--- a/components/Examples.vue
+++ b/components/Examples.vue
@@ -1,4 +1,8 @@
 <template>
+  <el-switch v-model="colorMode" inline-prompt active-text="暗夜" inactive-text="白天" size="large"></el-switch>
+
+  <br />
+
   <el-dropdown class="m-4" type="primary">
     <el-button type="primary">
       Dropdown List
@@ -56,4 +60,10 @@ import zhCn from "element-plus/es/locale/lang/zh-cn";
 const timeValue = ref("");
 const hello = () => ElMessage.info("hello world");
 const helloSuccess = () => ElMessage.success("hello world");
+
+const color = useColorMode();
+const colorMode = computed({
+  get: () => color.value === 'dark',
+    set: () => (color.preference = color.value === 'dark' ? 'light' : 'dark'),
+});
 </script>

--- a/components/Examples.vue
+++ b/components/Examples.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-switch v-model="colorMode" inline-prompt active-text="暗夜" inactive-text="白天" size="large"></el-switch>
+  <el-switch v-model="colorMode" inline-prompt active-text="dark" inactive-text="light" size="large"></el-switch>
 
   <br />
 
@@ -64,6 +64,6 @@ const helloSuccess = () => ElMessage.success("hello world");
 const color = useColorMode();
 const colorMode = computed({
   get: () => color.value === 'dark',
-    set: () => (color.preference = color.value === 'dark' ? 'light' : 'dark'),
+  set: () => (color.preference = color.value === 'dark' ? 'light' : 'dark'),
 });
 </script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -30,11 +30,17 @@ export default defineNuxtConfig({
     '@unocss/nuxt',
     '@pinia/nuxt',
     '@element-plus/nuxt',
+    '@nuxtjs/color-mode'
   ],
 
   // vueuse
   vueuse: {
     ssrHandlers: true,
+  },
+
+  // colorMode
+  colorMode: {
+    classSuffix: '',
   },
 
   unocss: {
@@ -44,8 +50,18 @@ export default defineNuxtConfig({
       scale: 1.2,
     },
   },
-
+  vite: {
+    css: {
+      preprocessorOptions: {
+        scss: {
+          additionalData: `@use "@/assets/scss/element/index.scss" as element;`,
+        },
+      },
+    },
+  },
   elementPlus: {
     icon: 'ElIcon',
+    importStyle: 'scss',
+    themes: ['dark'],
   },
 })

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@element-plus/icons-vue": "^2.0.10",
     "@element-plus/nuxt": "^1.0.2",
+    "@nuxtjs/color-mode": "^3.2.0",
     "@pinia/nuxt": "^0.4.6",
     "@unocss/nuxt": "^0.48.0",
     "@vueuse/nuxt": "^9.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.4
 specifiers:
   '@element-plus/icons-vue': ^2.0.10
   '@element-plus/nuxt': ^1.0.2
+  '@nuxtjs/color-mode': ^3.2.0
   '@pinia/nuxt': ^0.4.6
   '@unocss/nuxt': ^0.48.0
   '@vueuse/nuxt': ^9.9.0
@@ -15,6 +16,7 @@ specifiers:
 devDependencies:
   '@element-plus/icons-vue': 2.0.10
   '@element-plus/nuxt': 1.0.2_tjzx7iko7dkq2vnhx32zq7iuiu
+  '@nuxtjs/color-mode': 3.2.0
   '@pinia/nuxt': 0.4.6_typescript@4.9.4
   '@unocss/nuxt': 0.48.0
   '@vueuse/nuxt': 9.9.0_nuxt@3.0.0
@@ -707,6 +709,17 @@ packages:
       - typescript
       - vls
       - vti
+    dev: true
+
+  /@nuxtjs/color-mode/3.2.0:
+    resolution: {integrity: sha512-isDR01yfadopiHQ/VEVUpyNSPrk5PCjUHS4t1qYRZwuRGefU4s9Iaxf6H9nmr1QFzoMgTm+3T0r/54jLwtpZbA==}
+    dependencies:
+      '@nuxt/kit': 3.0.0
+      lodash.template: 4.5.0
+      pathe: 1.0.0
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
     dev: true
 
   /@pinia/nuxt/0.4.6_typescript@4.9.4:


### PR DESCRIPTION
1. 添加自定义主题.
2. 添加@nuxtjs/color-mode切换颜色模式.
3. 添加切换颜色模式实例.

![20230131114221](https://user-images.githubusercontent.com/45534519/215657549-fc9bfdc0-ea91-4d73-b0da-70b8bf200745.png)
![20230131114229](https://user-images.githubusercontent.com/45534519/215657560-c566fa74-88e7-4938-b8e6-e26da7902526.png)
